### PR TITLE
Creating integrated tests with security authorization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,13 @@
         </exclusion>
       </exclusions>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework.social</groupId>
       <artifactId>spring-social-facebook</artifactId>

--- a/src/main/java/br/com/annuum/capsicum/api/controller/ApplicationController.java
+++ b/src/main/java/br/com/annuum/capsicum/api/controller/ApplicationController.java
@@ -1,40 +1,50 @@
 package br.com.annuum.capsicum.api.controller;
 
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+
+import br.com.annuum.capsicum.api.security.UserPrincipal;
+import br.com.annuum.capsicum.api.service.ApplicationService;
 import javax.annotation.security.RolesAllowed;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController("/")
 public class ApplicationController {
 
+    @Autowired
+    private ApplicationService service;
+
     @GetMapping("/guest")
-    public ResponseEntity verifyGuest() {
-        return ResponseEntity.ok().body("Hello, Guest!");
+    public ResponseEntity verifyGuest(@AuthenticationPrincipal final UserPrincipal currentUser) {
+        return ResponseEntity.ok().body(service.greetings(ofNullable(currentUser)));
     }
 
     @GetMapping("/user")
     @RolesAllowed("USER")
-    public ResponseEntity verifyUser() {
-        return ResponseEntity.ok().body("Hello, User!");
+    public ResponseEntity verifyUser(@AuthenticationPrincipal final UserPrincipal currentUser) {
+        return ResponseEntity.ok().body(service.greetings(of(currentUser)));
     }
 
     @GetMapping("/group")
     @RolesAllowed("GROUP")
-    public ResponseEntity verifyGroup() {
-        return ResponseEntity.ok().body("Hello, Group!");
+    public ResponseEntity verifyGroup(@AuthenticationPrincipal final UserPrincipal currentUser) {
+        return ResponseEntity.ok().body(service.greetings(of(currentUser)));
     }
 
     @GetMapping("/organization")
     @RolesAllowed("ORGANIZATION")
-    public ResponseEntity verifyOrganization() {
-        return ResponseEntity.ok().body("Hello, Organization!");
+    public ResponseEntity verifyOrganization(@AuthenticationPrincipal final UserPrincipal currentUser) {
+        return ResponseEntity.ok().body(service.greetings(of(currentUser)));
     }
 
     @GetMapping("/volunteer")
     @RolesAllowed("VOLUNTEER")
-    public ResponseEntity verifyVolunteer() {
-        return ResponseEntity.ok().body("Hello, Volunteer!");
+    public ResponseEntity verifyVolunteer(@AuthenticationPrincipal final UserPrincipal currentUser) {
+        return ResponseEntity.ok().body(service.greetings(of(currentUser)));
     }
 
 }

--- a/src/main/java/br/com/annuum/capsicum/api/domain/AbstractUser.java
+++ b/src/main/java/br/com/annuum/capsicum/api/domain/AbstractUser.java
@@ -40,7 +40,6 @@ public abstract class AbstractUser implements User {
     @NotBlank
     private String password;
 
-    @NotNull
     @CreatedDate
     private LocalDateTime createdAt;
 }

--- a/src/main/java/br/com/annuum/capsicum/api/domain/Address.java
+++ b/src/main/java/br/com/annuum/capsicum/api/domain/Address.java
@@ -1,10 +1,15 @@
 package br.com.annuum.capsicum.api.domain;
 
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.experimental.Accessors;
-
-import javax.persistence.*;
-import javax.validation.constraints.NotNull;
 
 @Data
 @Accessors(chain = true)

--- a/src/main/java/br/com/annuum/capsicum/api/domain/UserVolunteer.java
+++ b/src/main/java/br/com/annuum/capsicum/api/domain/UserVolunteer.java
@@ -8,8 +8,6 @@ import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToOne;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -39,15 +37,12 @@ public class UserVolunteer extends AbstractUser {
 
     private String description;
 
-    @NotEmpty
     @ManyToMany
     private List<Cause> causeThatSupport;
 
-    @NotEmpty
     @ManyToMany
     private List<Skill> userSkills;
 
-    @NotNull
     @ColumnDefault("false")
     private Boolean hasCnh;
 

--- a/src/main/java/br/com/annuum/capsicum/api/security/JwtTokenProvider.java
+++ b/src/main/java/br/com/annuum/capsicum/api/security/JwtTokenProvider.java
@@ -45,7 +45,7 @@ public class JwtTokenProvider {
     return generate(userPrincipal);
   }
 
-  public String generate(final User user) {
+  private String generate(final User user) {
 
     log.info("Generating JWT Token... ");
     final LocalDateTime expiration = now().plusMinutes(jwtExpiration);

--- a/src/main/java/br/com/annuum/capsicum/api/service/ApplicationService.java
+++ b/src/main/java/br/com/annuum/capsicum/api/service/ApplicationService.java
@@ -1,0 +1,22 @@
+package br.com.annuum.capsicum.api.service;
+
+import static java.util.Objects.isNull;
+import static java.util.Optional.ofNullable;
+
+import br.com.annuum.capsicum.api.domain.enums.Profile;
+import br.com.annuum.capsicum.api.security.UserPrincipal;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ApplicationService {
+
+  public String greetings(final Optional<UserPrincipal> currentUser) {
+    if (currentUser.isPresent()) {
+      return "Hello, " + currentUser.get().getName() + " | " + currentUser.get().getProfile();
+    }
+
+    return "Hello, Guest | GUEST";
+  }
+
+}

--- a/src/test/java/br/com/annuum/capsicum/api/controller/ApplicationControllerIntegrationTest.java
+++ b/src/test/java/br/com/annuum/capsicum/api/controller/ApplicationControllerIntegrationTest.java
@@ -1,0 +1,79 @@
+package br.com.annuum.capsicum.api.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class ApplicationControllerIntegrationTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  public void greetingShouldReturnGreetingsToGuestFromService() throws Exception {
+    this.mockMvc.perform(get("/guest"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("Hello, Guest | GUEST")));
+  }
+
+  @Test
+  @WithUserDetails("voluntario@ajuda.ai")
+  public void greetingShouldReturnGreetingsToVolunteerFromService() throws Exception {
+    this.mockMvc.perform(get("/volunteer"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("Hello, Volunteer | VOLUNTEER")));
+  }
+
+  @Test
+  @WithUserDetails("grupo@ajuda.ai")
+  public void greetingShouldReturnGreetingsToGroupFromService() throws Exception {
+    this.mockMvc.perform(get("/group"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("Hello, Group | GROUP")));
+  }
+
+  @Test
+  @WithUserDetails("ong@ajuda.ai")
+  public void greetingShouldReturnGreetingsToOrganizationFromService() throws Exception {
+    this.mockMvc.perform(get("/organization"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("Hello, Organization | ORGANIZATION")));
+  }
+
+  @Test
+  @WithUserDetails("voluntario@ajuda.ai")
+  public void greetingShouldReturnGreetingsToVolunteerFromServiceForAllUsersEndpoint() throws Exception {
+    this.mockMvc.perform(get("/user"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("Hello, Volunteer | VOLUNTEER")));
+  }
+
+  @Test
+  @WithUserDetails("grupo@ajuda.ai")
+  public void greetingShouldReturnGreetingsToGroupFromServiceForAllUsersEndpoint() throws Exception {
+    this.mockMvc.perform(get("/user"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("Hello, Group | GROUP")));
+  }
+
+  @Test
+  @WithUserDetails("ong@ajuda.ai")
+  public void greetingShouldReturnGreetingsToOrganizationFromServiceForAllUsersEndpoint() throws Exception {
+    this.mockMvc.perform(get("/user"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("Hello, Organization | ORGANIZATION")));
+  }
+
+}

--- a/src/test/java/br/com/annuum/capsicum/api/test/utils/AbstractControllerIntegrationTest.java
+++ b/src/test/java/br/com/annuum/capsicum/api/test/utils/AbstractControllerIntegrationTest.java
@@ -1,0 +1,42 @@
+package br.com.annuum.capsicum.api.test.utils;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
+import java.nio.file.attribute.UserPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextTestExecutionListener;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+@TestExecutionListeners({
+    DependencyInjectionTestExecutionListener.class,
+    DirtiesContextTestExecutionListener.class,
+    WithSecurityContextTestExecutionListener.class})
+public abstract class AbstractControllerIntegrationTest {
+
+  @Autowired
+  protected WebApplicationContext context;
+
+  protected MockMvc mockMvc;
+
+  protected UserPrincipal currentUser;
+
+  @BeforeEach
+  public void setUp() {
+    mockMvc = MockMvcBuilders
+        .webAppContextSetup(context)
+        .apply(springSecurity())
+        .build();
+
+    currentUser =  (UserPrincipal)  SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+  }
+
+}

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,0 +1,5 @@
+insert into CITY (ID, NAME, GOOGLE_PLACE_CITY_ID, STATE) values (1000, 'São Leopoldo', 'place-id-sao-leopoldo', 'RS');
+insert into ADDRESS (ID, CITY_ID) values (1000, 1000);
+insert into USER_VOLUNTEER (ID, NAME, EMAIL, PASSWORD, CREATED_AT, ADDRESS_ID) values (1000, 'Volunteer', 'voluntario@ajuda.ai', '123456', '2020-04-10', 1000);
+insert into USER_GROUP (ID, NAME, EMAIL, PASSWORD, CREATED_AT, ADDRESS_ID) values (1001, 'Group', 'grupo@ajuda.ai', '123456', '2020-04-10', 1000);
+insert into USER_ORGANIZATION (ID, NAME, EMAIL, PASSWORD, CREATED_AT, ADDRESS_ID) values (1002, 'Organization', 'ong@ajuda.ai', '123456', '2020-04-10', 1000);


### PR DESCRIPTION
Adiciona dependências e exemplos de como usar testes integrados desde a controller usando a anotação `@RolesAllowed` até o repository. 

Usando a anotação `@WithUserDetails("email-do-usuario")`  é possível testar chamadas às controllers com usuários específicos. 

Como essa abordagem configura o Spring Security antes da execução do método de teste e antes do `@BeforeEach`, é necessário que usuário esteja previamente cadastrado antes. Por isso adicionei um arquivo `data.sql` na pasta `resources` com o objetivo de fazer a inicialiação de cada tipo de usuário para fazer os testes necessários.

- voluntario@ajuda.ai (ROLE_VOLUNTEER)
- grupo@ajuda.ai (ROLE_GROUP)
- ong@ajuda.ai (ROLE_ORGANIZATION)

É possível ainda testar endpoints públicos simplesmente não adicionando a anotação `@WithUserDetails`, nesse caso, ao injetar um usuário com `@AuthenticationPrincipal` será injetado apenas `null`. Ou seja, endpoints públicos devem considerar a ausência de UserPrincipal. 

Tomem o cuida de quando for passar um `UserPrincipal` em um endpoint público, de usar o `Optional` na service. Assim fica explícito que pode não ter um usuário autenticado. Nas outras, não usa Optional e tudo certo.