### PR TITLE
feat: volunteer availability mapped to string

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,12 @@
       <version>3.10</version>
     </dependency>
 
+    <dependency>
+      <groupId>one.util</groupId>
+      <artifactId>streamex</artifactId>
+      <version>0.7.2</version>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -132,6 +138,14 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/br/com/annuum/capsicum/api/controller/UserVolunteerController.java
+++ b/src/main/java/br/com/annuum/capsicum/api/controller/UserVolunteerController.java
@@ -3,6 +3,7 @@ package br.com.annuum.capsicum.api.controller;
 import br.com.annuum.capsicum.api.controller.request.UserVolunteerRequest;
 import br.com.annuum.capsicum.api.controller.response.UserVolunteerResponse;
 import br.com.annuum.capsicum.api.service.SaveUserVolunteerService;
+import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -16,7 +17,7 @@ public class UserVolunteerController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public UserVolunteerResponse saveUserVolunteer(@RequestBody final UserVolunteerRequest userVolunteerRequest) {
+    public UserVolunteerResponse saveUserVolunteer(@Valid @RequestBody final UserVolunteerRequest userVolunteerRequest) {
         return saveUserVolunteerService.save(userVolunteerRequest);
     }
 }

--- a/src/main/java/br/com/annuum/capsicum/api/controller/request/AvailabilityRequest.java
+++ b/src/main/java/br/com/annuum/capsicum/api/controller/request/AvailabilityRequest.java
@@ -1,0 +1,15 @@
+package br.com.annuum.capsicum.api.controller.request;
+
+import java.util.List;
+import javax.validation.constraints.NotEmpty;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class AvailabilityRequest {
+
+  @NotEmpty(message = "A lista de Disponibilidades não pode estar vazia.")
+  private List<DayShiftAvailabilityRequest> dayShiftAvailabilities;
+
+}

--- a/src/main/java/br/com/annuum/capsicum/api/controller/request/DayShiftAvailabilityRequest.java
+++ b/src/main/java/br/com/annuum/capsicum/api/controller/request/DayShiftAvailabilityRequest.java
@@ -1,0 +1,16 @@
+package br.com.annuum.capsicum.api.controller.request;
+
+import br.com.annuum.capsicum.api.domain.enums.DayShift;
+import java.time.DayOfWeek;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class DayShiftAvailabilityRequest {
+
+  private DayOfWeek dayOfWeek;
+
+  private DayShift dayShift;
+
+}

--- a/src/main/java/br/com/annuum/capsicum/api/controller/request/UserVolunteerRequest.java
+++ b/src/main/java/br/com/annuum/capsicum/api/controller/request/UserVolunteerRequest.java
@@ -1,14 +1,13 @@
 package br.com.annuum.capsicum.api.controller.request;
 
-import lombok.Data;
-import lombok.experimental.Accessors;
-import org.springframework.lang.Nullable;
-
+import java.util.List;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-import java.util.List;
+import lombok.Data;
+import lombok.experimental.Accessors;
+import org.springframework.lang.Nullable;
 
 @Data
 @Accessors(chain = true)
@@ -30,7 +29,10 @@ public class UserVolunteerRequest {
     @NotEmpty(message = "A lista de Habilidades não pode estar vazia.")
     private List<String> userSkills;
 
-    @NotNull(message = "O objeto Endereço não pode ser nulo.")
+    @NotNull(message = "A Disponibilidade não pode ser nula.")
+    private AvailabilityRequest availability;
+
+    @NotNull(message = "O Endereço não pode ser nulo.")
     private AddressRequest addressRequest;
 
     @NotNull(message = "É preciso informar se usuário possui CNH.")

--- a/src/main/java/br/com/annuum/capsicum/api/converter/AvailabilityConverter.java
+++ b/src/main/java/br/com/annuum/capsicum/api/converter/AvailabilityConverter.java
@@ -1,0 +1,78 @@
+package br.com.annuum.capsicum.api.converter;
+
+import static java.util.Arrays.asList;
+import static java.util.Objects.isNull;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.springframework.util.CollectionUtils.isEmpty;
+
+import br.com.annuum.capsicum.api.domain.Availability;
+import br.com.annuum.capsicum.api.domain.DayShiftAvailability;
+import br.com.annuum.capsicum.api.domain.enums.DayShift;
+import java.time.DayOfWeek;
+import java.util.List;
+import java.util.Map.Entry;
+import javax.persistence.AttributeConverter;
+import one.util.streamex.EntryStream;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AvailabilityConverter implements AttributeConverter<Availability, String> {
+
+  private static final char AVAILABLE = '1';
+  private static final char NOT_AVAILABLE = '0';
+
+  @Override
+  public String convertToDatabaseColumn(Availability attribute) {
+
+    // creates "000000000000000000000" considering 7 days of week and 3 day shifts
+    final String emptyValue = Character.toString(NOT_AVAILABLE).repeat(DayOfWeek.values().length * DayShift.values().length);
+
+    // return only zeros if availability not provided
+    if (isNull(attribute) || isEmpty(attribute.getDayShiftAvailabilities())) {
+      return emptyValue;
+    }
+
+    final StringBuilder builder = new StringBuilder(emptyValue);
+
+    // replace zero to one when availability occurs
+    attribute.getDayShiftAvailabilities()
+        .forEach(availability ->
+            builder.setCharAt(calculateIndex(availability), AVAILABLE));
+
+    return builder.toString();
+  }
+
+  @Override
+  public Availability convertToEntityAttribute(String dbData) {
+
+    final String data = isNull(dbData) ? EMPTY : dbData;
+    final List<DayShiftAvailability> values = EntryStream.of(asList(data.split(EMPTY)))
+        .filterValues(this::isAvailable)
+        .map(this::toDayShiftAvailability)
+        .toList();
+
+    return new Availability()
+        .setDayShiftAvailabilities(values);
+  }
+
+  private int calculateIndex(final DayShiftAvailability availability) {
+    int dayOfWeek = availability.getDayOfWeek().getValue() - 1;
+    int dayShift = availability.getDayShift().getValue() - 1;
+    return dayOfWeek * DayShift.values().length + dayShift;
+  }
+
+  private boolean isAvailable(final String value) {
+    return Character.toString(AVAILABLE).equals(value);
+  }
+
+  private DayShiftAvailability toDayShiftAvailability(Entry<Integer, String> integerStringEntry) {
+    int index = integerStringEntry.getKey();
+    int dayOfWeekValue = index / DayShift.values().length + 1;
+    int dayShiftValue = index % DayShift.values().length + 1;
+
+    return new DayShiftAvailability()
+        .setDayOfWeek(DayOfWeek.of(dayOfWeekValue))
+        .setDayShift(DayShift.of(dayShiftValue));
+  }
+
+}

--- a/src/main/java/br/com/annuum/capsicum/api/domain/Availability.java
+++ b/src/main/java/br/com/annuum/capsicum/api/domain/Availability.java
@@ -1,0 +1,13 @@
+package br.com.annuum.capsicum.api.domain;
+
+import java.util.List;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class Availability {
+
+  private List<DayShiftAvailability> dayShiftAvailabilities;
+
+}

--- a/src/main/java/br/com/annuum/capsicum/api/domain/DayShiftAvailability.java
+++ b/src/main/java/br/com/annuum/capsicum/api/domain/DayShiftAvailability.java
@@ -1,0 +1,16 @@
+package br.com.annuum.capsicum.api.domain;
+
+import br.com.annuum.capsicum.api.domain.enums.DayShift;
+import java.time.DayOfWeek;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class DayShiftAvailability {
+
+  private DayOfWeek dayOfWeek;
+
+  private DayShift dayShift;
+
+}

--- a/src/main/java/br/com/annuum/capsicum/api/domain/UserVolunteer.java
+++ b/src/main/java/br/com/annuum/capsicum/api/domain/UserVolunteer.java
@@ -2,8 +2,10 @@ package br.com.annuum.capsicum.api.domain;
 
 import static br.com.annuum.capsicum.api.domain.enums.Profile.VOLUNTEER;
 
+import br.com.annuum.capsicum.api.converter.AvailabilityConverter;
 import br.com.annuum.capsicum.api.domain.enums.Profile;
 import java.util.List;
+import javax.persistence.Convert;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.ManyToMany;
@@ -24,30 +26,34 @@ import org.hibernate.annotations.ColumnDefault;
 @Entity
 public class UserVolunteer extends AbstractUser {
 
-    private String phone;
+  private String phone;
 
-    @NotNull
-    @OneToOne
-    private Address address;
+  @NotNull
+  @OneToOne
+  private Address address;
 
-    @Embedded
-    private LocationCoordinates actualLocationCoordinates;
+  @Embedded
+  private LocationCoordinates actualLocationCoordinates;
 
-    private Long profilePictureId;
+  private Long profilePictureId;
 
-    private String description;
+  private String description;
 
-    @ManyToMany
-    private List<Cause> causeThatSupport;
+  @ManyToMany
+  private List<Cause> causeThatSupport;
 
-    @ManyToMany
-    private List<Skill> userSkills;
+  @ManyToMany
+  private List<Skill> userSkills;
 
-    @ColumnDefault("false")
-    private Boolean hasCnh;
+  @Convert(converter = AvailabilityConverter.class)
+  private Availability availability;
 
-    @Override
-    public Profile getProfile() {
-        return VOLUNTEER;
-    }
+  @ColumnDefault("false")
+  private Boolean hasCnh;
+
+  @Override
+  public Profile getProfile() {
+    return VOLUNTEER;
+  }
+
 }

--- a/src/main/java/br/com/annuum/capsicum/api/domain/enums/DayShift.java
+++ b/src/main/java/br/com/annuum/capsicum/api/domain/enums/DayShift.java
@@ -1,0 +1,26 @@
+package br.com.annuum.capsicum.api.domain.enums;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum DayShift {
+
+  MORNING(1, "Manhã"),
+  AFTERMOON(2, "Tarde"),
+  NIGHT(3, "Noite");
+
+  private int value;
+  private String description;
+
+  public static DayShift of(final int value) {
+    for (DayShift dayShift : values()) {
+      if (dayShift.getValue() == value) {
+        return dayShift;
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/br/com/annuum/capsicum/api/service/SaveUserVolunteerService.java
+++ b/src/main/java/br/com/annuum/capsicum/api/service/SaveUserVolunteerService.java
@@ -4,7 +4,13 @@ import static java.util.Objects.nonNull;
 
 import br.com.annuum.capsicum.api.controller.request.UserVolunteerRequest;
 import br.com.annuum.capsicum.api.controller.response.UserVolunteerResponse;
-import br.com.annuum.capsicum.api.domain.*;
+import br.com.annuum.capsicum.api.domain.Address;
+import br.com.annuum.capsicum.api.domain.Availability;
+import br.com.annuum.capsicum.api.domain.Cause;
+import br.com.annuum.capsicum.api.domain.DayShiftAvailability;
+import br.com.annuum.capsicum.api.domain.LocationCoordinates;
+import br.com.annuum.capsicum.api.domain.Skill;
+import br.com.annuum.capsicum.api.domain.UserVolunteer;
 import br.com.annuum.capsicum.api.repository.UserVolunteerRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,49 +24,55 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class SaveUserVolunteerService {
 
-    @Autowired
-    private FindSkillByDescriptionService findSkillByDescriptionService;
+  @Autowired
+  private FindSkillByDescriptionService findSkillByDescriptionService;
 
-    @Autowired
-    private FindCauseByDescriptionService findCauseByDescriptionService;
+  @Autowired
+  private FindCauseByDescriptionService findCauseByDescriptionService;
 
-    @Autowired
-    private UserVolunteerRepository userVolunteerRepository;
+  @Autowired
+  private UserVolunteerRepository userVolunteerRepository;
 
-    @Autowired
-    private SaveAddressService saveAddressService;
+  @Autowired
+  private SaveAddressService saveAddressService;
 
-    @Autowired
-    private ModelMapper modelMapper;
+  @Autowired
+  private ModelMapper modelMapper;
 
-    @Transactional
-    public UserVolunteerResponse save(final UserVolunteerRequest userVolunteerRequest) {
+  @Transactional
+  public UserVolunteerResponse save(final UserVolunteerRequest userVolunteerRequest) {
 
-        log.info("Start to create an UserVolunteer for: '{}'", userVolunteerRequest);
-        final Address address = saveAddressService.saveAddress(userVolunteerRequest.getAddressRequest());
+    log.info("Start to create an UserVolunteer for: '{}'", userVolunteerRequest);
+    final Address address = saveAddressService.saveAddress(userVolunteerRequest.getAddressRequest());
 
-        final List<Cause> causesThatSupport = userVolunteerRequest.getCauseThatSupport()
-                .stream()
-                .map(cause -> findCauseByDescriptionService.find(cause))
-                .collect(Collectors.toList());
+    final List<Cause> causesThatSupport = userVolunteerRequest.getCauseThatSupport()
+        .stream()
+        .map(cause -> findCauseByDescriptionService.find(cause))
+        .collect(Collectors.toList());
 
-        final List<Skill> userSkills = userVolunteerRequest.getUserSkills()
-                .stream()
-                .map(skill -> findSkillByDescriptionService.find(skill))
-                .collect(Collectors.toList());
+    final List<Skill> userSkills = userVolunteerRequest.getUserSkills()
+        .stream()
+        .map(skill -> findSkillByDescriptionService.find(skill))
+        .collect(Collectors.toList());
 
-        log.info("Building UserVolunteer to persist");
-        final UserVolunteer userVolunteer = modelMapper.map(userVolunteerRequest, UserVolunteer.class)
-                .setAddress(address)
-                .setCauseThatSupport(causesThatSupport)
-                .setUserSkills(userSkills);
+    final List<DayShiftAvailability> availability = userVolunteerRequest.getAvailability().getDayShiftAvailabilities()
+        .stream()
+        .map(dayShft -> modelMapper.map(dayShft, DayShiftAvailability.class))
+        .collect(Collectors.toList());
 
-        if (nonNull(userVolunteerRequest.getActualLocationCoordinatesRequest())) {
-            log.info("Getting LocationCoordinates from user");
-            userVolunteer.setActualLocationCoordinates(modelMapper.map(userVolunteerRequest.getActualLocationCoordinatesRequest(), LocationCoordinates.class));
-        }
+    log.info("Building UserVolunteer to persist");
+    final UserVolunteer userVolunteer = modelMapper.map(userVolunteerRequest, UserVolunteer.class)
+        .setAddress(address)
+        .setCauseThatSupport(causesThatSupport)
+        .setUserSkills(userSkills)
+        .setAvailability(new Availability().setDayShiftAvailabilities(availability));
 
-        log.info("Creating a new UserVolunteer: '{}'", userVolunteer);
-        return modelMapper.map(userVolunteerRepository.save(userVolunteer), UserVolunteerResponse.class);
+    if (nonNull(userVolunteerRequest.getActualLocationCoordinatesRequest())) {
+      log.info("Getting LocationCoordinates from user");
+      userVolunteer.setActualLocationCoordinates(modelMapper.map(userVolunteerRequest.getActualLocationCoordinatesRequest(), LocationCoordinates.class));
     }
+
+    log.info("Creating a new UserVolunteer: '{}'", userVolunteer);
+    return modelMapper.map(userVolunteerRepository.save(userVolunteer), UserVolunteerResponse.class);
+  }
 }

--- a/src/test/java/br/com/annuum/capsicum/api/converter/AvailabilityConverterTest.java
+++ b/src/test/java/br/com/annuum/capsicum/api/converter/AvailabilityConverterTest.java
@@ -1,0 +1,365 @@
+package br.com.annuum.capsicum.api.converter;
+
+import static br.com.annuum.capsicum.api.domain.enums.DayShift.AFTERMOON;
+import static br.com.annuum.capsicum.api.domain.enums.DayShift.MORNING;
+import static br.com.annuum.capsicum.api.domain.enums.DayShift.NIGHT;
+import static java.time.DayOfWeek.FRIDAY;
+import static java.time.DayOfWeek.MONDAY;
+import static java.time.DayOfWeek.SATURDAY;
+import static java.time.DayOfWeek.SUNDAY;
+import static java.time.DayOfWeek.THURSDAY;
+import static java.time.DayOfWeek.TUESDAY;
+import static java.time.DayOfWeek.WEDNESDAY;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import br.com.annuum.capsicum.api.domain.Availability;
+import br.com.annuum.capsicum.api.domain.DayShiftAvailability;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+class AvailabilityConverterTest {
+
+  private AvailabilityConverter target = new AvailabilityConverter();
+
+  //  --------------------
+  // | TO DATABASE COLUMN |
+  //  --------------------
+
+  @Test
+  public void shouldConvertToDatabaseColumnWithEmptyAvailabilityWhenNull() {
+
+    final String column = target.convertToDatabaseColumn(null);
+
+    assertEquals("000000000000000000000", column);
+  }
+
+  @Test
+  public void shouldConvertToDatabaseColumnWithEmptyAvailabilityWhenEmptyDayShiftAvailability() {
+
+    final Availability attribute = new Availability()
+        .setDayShiftAvailabilities(new ArrayList<>());
+
+    final String column = target.convertToDatabaseColumn(attribute);
+
+    assertEquals("000000000000000000000", column);
+  }
+
+  @Test
+  public void shouldConvertToDatabaseColumnWithFirstAndLastDayShiftAvailableIndicatingMondayMorningAndSundayNight() {
+
+    final Availability attribute = new Availability()
+        .setDayShiftAvailabilities(asList(
+            new DayShiftAvailability()
+                .setDayOfWeek(MONDAY)
+                .setDayShift(MORNING),
+            new DayShiftAvailability()
+                .setDayOfWeek(SUNDAY)
+                .setDayShift(NIGHT)
+        ));
+
+    final String column = target.convertToDatabaseColumn(attribute);
+
+    assertEquals("100000000000000000001", column);
+  }
+
+  @Test
+  public void shouldConvertToDatabaseColumnWithEveryMorningsAvailable() {
+
+    final Availability attribute = new Availability()
+        .setDayShiftAvailabilities(asList(
+            new DayShiftAvailability()
+                .setDayOfWeek(MONDAY)
+                .setDayShift(MORNING),
+            new DayShiftAvailability()
+                .setDayOfWeek(TUESDAY)
+                .setDayShift(MORNING),
+            new DayShiftAvailability()
+                .setDayOfWeek(WEDNESDAY)
+                .setDayShift(MORNING),
+            new DayShiftAvailability()
+                .setDayOfWeek(THURSDAY)
+                .setDayShift(MORNING),
+            new DayShiftAvailability()
+                .setDayOfWeek(FRIDAY)
+                .setDayShift(MORNING),
+            new DayShiftAvailability()
+                .setDayOfWeek(SATURDAY)
+                .setDayShift(MORNING),
+            new DayShiftAvailability()
+                .setDayOfWeek(SUNDAY)
+                .setDayShift(MORNING)
+        ));
+
+    final String column = target.convertToDatabaseColumn(attribute);
+
+    assertEquals("100100100100100100100", column);
+  }
+
+  @Test
+  public void shouldConvertToDatabaseColumnWithAvailabilityOnlyOnWeekends() {
+
+    final Availability attribute = new Availability()
+        .setDayShiftAvailabilities(asList(
+            new DayShiftAvailability()
+                .setDayOfWeek(SATURDAY)
+                .setDayShift(MORNING),
+            new DayShiftAvailability()
+                .setDayOfWeek(SATURDAY)
+                .setDayShift(AFTERMOON),
+            new DayShiftAvailability()
+                .setDayOfWeek(SATURDAY)
+                .setDayShift(NIGHT),
+            new DayShiftAvailability()
+                .setDayOfWeek(SUNDAY)
+                .setDayShift(MORNING),
+            new DayShiftAvailability()
+                .setDayOfWeek(SUNDAY)
+                .setDayShift(AFTERMOON),
+            new DayShiftAvailability()
+                .setDayOfWeek(SUNDAY)
+                .setDayShift(NIGHT)
+        ));
+
+    final String column = target.convertToDatabaseColumn(attribute);
+
+    assertEquals("000000000000000111111", column);
+  }
+
+  @Test
+  public void shouldConvertToDatabaseColumnWithAvailabilityOnlyOnWeekDays() {
+
+    final Availability attribute = new Availability()
+        .setDayShiftAvailabilities(asList(
+            new DayShiftAvailability()
+                .setDayOfWeek(MONDAY)
+                .setDayShift(MORNING),
+            new DayShiftAvailability()
+                .setDayOfWeek(MONDAY)
+                .setDayShift(AFTERMOON),
+            new DayShiftAvailability()
+                .setDayOfWeek(MONDAY)
+                .setDayShift(NIGHT),
+            new DayShiftAvailability()
+                .setDayOfWeek(TUESDAY)
+                .setDayShift(MORNING),
+            new DayShiftAvailability()
+                .setDayOfWeek(TUESDAY)
+                .setDayShift(AFTERMOON),
+            new DayShiftAvailability()
+                .setDayOfWeek(TUESDAY)
+                .setDayShift(NIGHT),
+            new DayShiftAvailability()
+                .setDayOfWeek(WEDNESDAY)
+                .setDayShift(MORNING),
+            new DayShiftAvailability()
+                .setDayOfWeek(WEDNESDAY)
+                .setDayShift(AFTERMOON),
+            new DayShiftAvailability()
+                .setDayOfWeek(WEDNESDAY)
+                .setDayShift(NIGHT),
+            new DayShiftAvailability()
+                .setDayOfWeek(THURSDAY)
+                .setDayShift(MORNING),
+            new DayShiftAvailability()
+                .setDayOfWeek(THURSDAY)
+                .setDayShift(AFTERMOON),
+            new DayShiftAvailability()
+                .setDayOfWeek(THURSDAY)
+                .setDayShift(NIGHT),
+            new DayShiftAvailability()
+                .setDayOfWeek(FRIDAY)
+                .setDayShift(MORNING),
+            new DayShiftAvailability()
+                .setDayOfWeek(FRIDAY)
+                .setDayShift(AFTERMOON),
+            new DayShiftAvailability()
+                .setDayOfWeek(FRIDAY)
+                .setDayShift(NIGHT)
+        ));
+
+    final String column = target.convertToDatabaseColumn(attribute);
+
+    assertEquals("111111111111111000000", column);
+  }
+
+  //  ---------------------
+  // | TO ENTITY ATTRIBUTE |
+  //  ---------------------
+
+  @Test
+  public void shouldConvertToEntityWithEmptyAvailabilityWhenNull() {
+
+    final Availability availability = target.convertToEntityAttribute(null);
+
+    assertEquals(0, availability.getDayShiftAvailabilities().size());
+  }
+
+  @Test
+  public void shouldConvertToEntityWithEmptyAvailabilityWhenEmptyDayShiftAvailability() {
+
+    final String column = "000000000000000000000";
+
+    final Availability availability = target.convertToEntityAttribute(column);
+
+    assertEquals(0, availability.getDayShiftAvailabilities().size());
+  }
+
+  @Test
+  public void shouldConvertToEntityWithFirstAndLastDayShiftAvailableIndicatingMondayMorningAndSundayNight() {
+
+    final String column = "100000000000000000001";
+
+    final Availability availability = target.convertToEntityAttribute(column);
+
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(MONDAY)
+          .setDayShift(MORNING)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(SUNDAY)
+          .setDayShift(NIGHT)));
+  }
+
+  @Test
+  public void shouldConvertToEntityWithEveryMorningsAvailable() {
+
+    final String column = "100100100100100100100";
+
+    final Availability availability = target.convertToEntityAttribute(column);
+
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(MONDAY)
+          .setDayShift(MORNING)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(TUESDAY)
+          .setDayShift(MORNING)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(WEDNESDAY)
+          .setDayShift(MORNING)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(THURSDAY)
+          .setDayShift(MORNING)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(FRIDAY)
+          .setDayShift(MORNING)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(SATURDAY)
+          .setDayShift(MORNING)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(SUNDAY)
+          .setDayShift(MORNING)));
+  }
+
+  @Test
+  public void shouldConvertToEntityWithAvailabilityOnlyOnWeekends() {
+
+    final String column = "000000000000000111111";
+
+    final Availability availability = target.convertToEntityAttribute(column);
+
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(SATURDAY)
+          .setDayShift(MORNING)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(SATURDAY)
+          .setDayShift(AFTERMOON)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(SATURDAY)
+          .setDayShift(NIGHT)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(SUNDAY)
+          .setDayShift(MORNING)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(SUNDAY)
+          .setDayShift(AFTERMOON)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(SUNDAY)
+          .setDayShift(NIGHT)));
+  }
+
+  @Test
+  public void shouldConvertToEntityWithAvailabilityOnlyOnWeekDays() {
+
+    final String column = "111111111111111000000";
+
+    final Availability availability = target.convertToEntityAttribute(column);
+
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(MONDAY)
+          .setDayShift(MORNING)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(MONDAY)
+          .setDayShift(AFTERMOON)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(MONDAY)
+          .setDayShift(NIGHT)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(TUESDAY)
+          .setDayShift(MORNING)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(TUESDAY)
+          .setDayShift(AFTERMOON)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(TUESDAY)
+          .setDayShift(NIGHT)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(WEDNESDAY)
+          .setDayShift(MORNING)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(WEDNESDAY)
+          .setDayShift(AFTERMOON)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(WEDNESDAY)
+          .setDayShift(NIGHT)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(THURSDAY)
+          .setDayShift(MORNING)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(THURSDAY)
+          .setDayShift(AFTERMOON)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(THURSDAY)
+          .setDayShift(NIGHT)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(FRIDAY)
+          .setDayShift(MORNING)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(FRIDAY)
+          .setDayShift(AFTERMOON)));
+    assertTrue(availability.getDayShiftAvailabilities().contains(
+        new DayShiftAvailability()
+          .setDayOfWeek(FRIDAY)
+          .setDayShift(NIGHT)));
+  }
+
+}


### PR DESCRIPTION
Criação dos objetos Availabilit e DayShiftAvailability, sendo que o primeiro existe apenas como programação defensiva prevendo uma possível adição de funcionalidades além das previstas atualmente. Para o dia da semana foi utilizado o enum da java.time, o DayOfWeek, mas para os turnos não encontrei nada na api de data e hora do java, então criei o enum DayShift, que contém os valores para Manhã, Tarde e Noite.

Esses dados são persistidos no bando em formato de uma String de 0 e 1, onde o 1 representa os turnos em que o usuário tem disponibilidade, Essa transformação é feita no AvailabilityConverter que possui o método para transformar em String (database column) e o método para transformar em Availability (entity attribute).  Foram criados 5 cenários de testes para cada transformação buscando abranger a maioria dos cenários possíveis. Se encontrar um cenário não coberto, reporte, por favor.

**Importante**: Eu estou usando um recurso bem simples do Java 11 para criar uma String dinamicamente. Por ora não vi nenhum problema no upgrade da JDK, se virem que isso pode ser um problema, reporte pra que eu possa resolver de outra forma.