### PR TITLE
Add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false
+
+[COMMIT_EDITMSG]
+max_line_length = 0
+
+[*.java]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[{package.json, *.yml}]
+indent_style = space
+indent_size = 2
+
+[*.xml]
+indent_size = 4


### PR DESCRIPTION
Adicionei esse .editorconfig pra tentarmos padronizar minimamente nossas configurações de tabulação da IDE.

A ideia é evitar as diffs por causa do auto-format da IDE