### PR TITLE
Simplificando domínio de endereço

### DIFF
--- a/src/main/java/br/com/annuum/capsicum/api/controller/request/AddressRequest.java
+++ b/src/main/java/br/com/annuum/capsicum/api/controller/request/AddressRequest.java
@@ -10,13 +10,17 @@ import javax.validation.constraints.NotNull;
 @Accessors(chain = true)
 public class AddressRequest {
 
-    private Long idCity;
-
     @NotNull(message = "A latitude precisa ser informada.")
     private Double latitude;
 
     @NotNull(message = "A longitude precisa ser informada.")
     private Double longitude;
+
+    @NotNull
+    private String cityName;
+
+    @NotNull
+    private String federatedUnityAcronym;
 
     @Nullable
     private String district;

--- a/src/main/java/br/com/annuum/capsicum/api/controller/request/UserGroupRequest.java
+++ b/src/main/java/br/com/annuum/capsicum/api/controller/request/UserGroupRequest.java
@@ -41,5 +41,8 @@ public class UserGroupRequest {
     private String profilePictureUrl;
 
     @Nullable
+    private String profilePictureKey;
+
+    @Nullable
     private String description;
 }

--- a/src/main/java/br/com/annuum/capsicum/api/controller/request/UserOrganizationRequest.java
+++ b/src/main/java/br/com/annuum/capsicum/api/controller/request/UserOrganizationRequest.java
@@ -49,6 +49,9 @@ public class UserOrganizationRequest {
     private String profilePictureUrl;
 
     @Nullable
+    private String profilePictureKey;
+
+    @Nullable
     private String backgroundPictureUrl;
 
     @Nullable

--- a/src/main/java/br/com/annuum/capsicum/api/controller/request/UserVolunteerRequest.java
+++ b/src/main/java/br/com/annuum/capsicum/api/controller/request/UserVolunteerRequest.java
@@ -48,6 +48,9 @@ public class UserVolunteerRequest {
     private String profilePictureUrl;
 
     @Nullable
+    private String profilePictureKey;
+
+    @Nullable
     private String facebookUrl;
 
     @Nullable

--- a/src/main/java/br/com/annuum/capsicum/api/domain/Address.java
+++ b/src/main/java/br/com/annuum/capsicum/api/domain/Address.java
@@ -27,8 +27,11 @@ public class Address {
     @Column(columnDefinition = "geography(POINT, 4326)")
     private Point geolocation;
 
-    @ManyToOne
-    private City city;
+    @NotNull
+    private String cityName;
+
+    @NotNull
+    private String federatedUnityAcronym;
 
     private String district;
 

--- a/src/main/java/br/com/annuum/capsicum/api/domain/FederatedUnity.java
+++ b/src/main/java/br/com/annuum/capsicum/api/domain/FederatedUnity.java
@@ -3,6 +3,7 @@ package br.com.annuum.capsicum.api.domain;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
@@ -14,6 +15,7 @@ public class FederatedUnity {
     @Id
     private Long id;
 
+    @Column(unique=true)
     private String acronym;
 
     private String name;

--- a/src/main/java/br/com/annuum/capsicum/api/domain/UserGroup.java
+++ b/src/main/java/br/com/annuum/capsicum/api/domain/UserGroup.java
@@ -51,6 +51,8 @@ public class UserGroup extends AbstractUser {
 
     private String profilePictureUrl;
 
+    private String profilePictureKey;
+
     private String backgroundPictureUrl;
 
     @Override

--- a/src/main/java/br/com/annuum/capsicum/api/domain/UserOrganization.java
+++ b/src/main/java/br/com/annuum/capsicum/api/domain/UserOrganization.java
@@ -56,6 +56,8 @@ public class UserOrganization extends AbstractUser {
 
     private String profilePictureId;
 
+    private String profilePictureKey;
+
     private String backgroundPictureId;
 
     @Override

--- a/src/main/java/br/com/annuum/capsicum/api/domain/UserVolunteer.java
+++ b/src/main/java/br/com/annuum/capsicum/api/domain/UserVolunteer.java
@@ -59,6 +59,8 @@ public class UserVolunteer extends AbstractUser {
 
     private String profilePictureUrl;
 
+    private String profilePictureKey;
+
     @Override
     public Profile getProfile() {
         return VOLUNTEER;

--- a/src/main/java/br/com/annuum/capsicum/api/service/SaveAddressService.java
+++ b/src/main/java/br/com/annuum/capsicum/api/service/SaveAddressService.java
@@ -3,7 +3,6 @@ package br.com.annuum.capsicum.api.service;
 import br.com.annuum.capsicum.api.component.PointFactory;
 import br.com.annuum.capsicum.api.controller.request.AddressRequest;
 import br.com.annuum.capsicum.api.domain.Address;
-import br.com.annuum.capsicum.api.domain.City;
 import br.com.annuum.capsicum.api.repository.AddressRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
@@ -12,14 +11,9 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 
-import static java.util.Optional.ofNullable;
-
 @Service
 @Slf4j
 public class SaveAddressService {
-
-    @Autowired
-    private FindCityByIdService findCityByIdService;
 
     @Autowired
     private AddressRepository addressRepository;
@@ -34,14 +28,9 @@ public class SaveAddressService {
     public Address save(final AddressRequest addressRequest) {
         log.info("Start to create an Address for: '{}'", addressRequest);
 
-        final City city = ofNullable(addressRequest.getIdCity())
-            .map(findCityByIdService::find)
-            .orElse(null);
-
         log.info("Building Address to persist");
         final Address addressToPersist = modelMapper.map(addressRequest, Address.class)
-            .setGeolocation(pointFactory.createPointFromCoordinates(addressRequest.getLatitude(), addressRequest.getLongitude()))
-            .setCity(city);
+            .setGeolocation(pointFactory.createPointFromCoordinates(addressRequest.getLatitude(), addressRequest.getLongitude()));
 
         log.info("Creating a new Address: '{}'", addressToPersist);
         return addressRepository.save(addressToPersist);

--- a/src/test/java/br/com/annuum/capsicum/api/service/SaveAddressServiceTest.java
+++ b/src/test/java/br/com/annuum/capsicum/api/service/SaveAddressServiceTest.java
@@ -25,9 +25,6 @@ class SaveAddressServiceTest {
     private SaveAddressService saveAddressService;
 
     @Mock
-    private FindCityByIdService findCityByIdService;
-
-    @Mock
     private AddressRepository addressRepository;
 
     @Mock
@@ -38,23 +35,18 @@ class SaveAddressServiceTest {
 
     @Test
     public void mustSaveAndReturnPersistedAddress_withSuccess() {
-        // Arrange
-        final City city = new City()
-            .setId(1L)
-            .setName("someCityName")
-            .setFederatedUnity(Mockito.mock(FederatedUnity.class));
+        // Arrang
         final Point geolocation = Mockito.mock(Point.class);
         final Address expectedAddress = new Address()
             .setId(1L)
-            .setCity(city)
+            .setCityName("someCityName")
+            .setFederatedUnityAcronym("someFederatedUnityAcronym")
             .setStreetName("someStreet")
             .setLatitude(1D)
             .setLongitude(1D)
             .setGeolocation(geolocation);
         final AddressRequest addressRequest = Mockito.mock(AddressRequest.class);
 
-        when(findCityByIdService.find(addressRequest.getIdCity()))
-            .thenReturn(city);
         when(modelMapper.map(addressRequest, Address.class))
             .thenReturn(expectedAddress);
         when(pointFactory.createPointFromCoordinates(addressRequest.getLatitude(), addressRequest.getLongitude()))
@@ -82,7 +74,6 @@ class SaveAddressServiceTest {
             .setGeolocation(geolocation);
         final AddressRequest addressRequest = Mockito.mock(AddressRequest.class);
 
-        verifyNoMoreInteractions(findCityByIdService);
         when(modelMapper.map(addressRequest, Address.class))
             .thenReturn(expectedAddress);
         when(pointFactory.createPointFromCoordinates(addressRequest.getLatitude(), addressRequest.getLongitude()))


### PR DESCRIPTION
Removendo id da cidade no request pra salvar um novo usuário. No lugar estão sendo informados o nome da cidade e a sigla do estado já que esses dados são usados apenas para exibição.

Além disso, foi adicionado o campo key da foto do perfil que será usado pra identificar uma imagem no AWS S3